### PR TITLE
eirinifs source is configured through bits helm template [#164168224]

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ This is a `helm` release for Project [Eirini](https://code.cloudfoundry.org/eiri
 
 1. Export the Registry certificate in the `BITS_TLS_KEY` and `BITS_TLS_CRT` environment variables. (see [Certificates](#Certificates))
 
+1. Set the environemnt varialbe `EIRINI_ROOTFS_VERSION`. This will donwload the mentioned version of `eirinifs.tar`. (see [eirinifs releases](https://github.com/cloudfoundry-incubator/eirinifs/releases))
 1. Install CF:
 
     ```bash
-    helm install eirini/cf --namespace scf --name scf --values <your-values.yaml> --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=${BITS_TLS_KEY}" --set "eirini.secrets.BITS_TLS_CRT=${BITS_TLS_CRT}"
+    helm install eirini/cf --namespace scf --name scf --values <your-values.yaml> --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=${BITS_TLS_KEY}" --set "eirini.secrets.BITS_TLS_CRT=${BITS_TLS_CRT}" --set "eirini.EIRINI_ROOTFS_VERSION=${EIRINI_ROOTFS_VERSION}"
     ```
 
 1. Use the following command to verify that every CF control plane pod is `running` and `ready`:

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -130,7 +130,7 @@ spec:
           mountPath: /assets/
       initContainers:
       - name: "download-eirini-rootfs"
-        image: kiranjain2/eirinidownloader:latest
+        image: flintstonecf/eirinifs-downloader:latest
         env:
         - name: EIRINI_ROOTFS_VERSION
           value: {{ .Values.EIRINI_ROOTFS_VERSION }}

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -130,7 +130,10 @@ spec:
           mountPath: /assets/
       initContainers:
       - name: "download-eirini-rootfs"
-        image: flintstonecf/eirinifs-downloader:latest
+        image: kiranjain2/eirinidownloader:latest
+        env:
+        - name: EIRINI_ROOTFS_VERSION
+          value: {{ .Values.EIRINI_ROOTFS_VERSION }}
         command: ["/bin/sh", "-c", "./eirini-rootfs-downloader.sh"]
         volumeMounts:
         - name: bits-assets

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -28,5 +28,4 @@ env:
   # Base domain of the SCF cluster.
   # Example: "my-scf-cluster.com"
   DOMAIN: ~
-
-EIRINI_ROOTFS_VERSION: v35.0.0
+EIRINI_ROOTFS_VERSION: 

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -28,3 +28,5 @@ env:
   # Base domain of the SCF cluster.
   # Example: "my-scf-cluster.com"
   DOMAIN: ~
+
+EIRINI_ROOTFS_VERSION: v35.0.0


### PR DESCRIPTION

This is for 
1. Specifying the eirinifs version explicitly. This resolve the concern of having latest eirinfs every time.

How it works
1. Run the Kubernetes cf cluster and follow the instructions on README mentioned the changes in the steps.